### PR TITLE
avoid java 11 api

### DIFF
--- a/src/main/kotlin/io/openapiprocessor/core/support/Path.kt
+++ b/src/main/kotlin/io/openapiprocessor/core/support/Path.kt
@@ -14,4 +14,4 @@ fun Path.deleteRecursively() =
         .forEach(Files::delete)
 
 val Path.text: String
-    get() = Files.readString(this)
+    get() = String(Files.readAllBytes(this))


### PR DESCRIPTION
avoid java 11 api